### PR TITLE
Add the mergeServiceFiles config for shadowJar

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -74,6 +74,10 @@ task javadocJar(type: Jar) {
     from javadoc
 }
 
+shadowJar {
+    mergeServiceFiles()
+}
+
 sourceCompatibility = 1.8
 targetCompatibility = 1.8
 


### PR DESCRIPTION
I faced the similar issue to the issue mentioned in the following article:
https://stackoverflow.com/questions/55484043/how-to-fix-could-not-find-policy-pick-first-with-google-tts-java-client

As this article says, after adding the `mergeServiceFiles` config for `shadowJar` in `build.gradle`, the issue is fixed.

Please take a look!