### PR TITLE
Fix the behavior with --wait-outstanding option

### DIFF
--- a/src/main/java/com/scalar/admin/AdminCommand.java
+++ b/src/main/java/com/scalar/admin/AdminCommand.java
@@ -34,11 +34,11 @@ public class AdminCommand implements Callable<Integer> {
   private String srvServiceUrl;
 
   @CommandLine.Option(
-      names = {"--wait-outstanding", "-w"},
+      names = {"--no-wait", "-n"},
       defaultValue = "false",
       description =
           "A flag to specify if PAUSE command waits for termination of outstanding requests.")
-  private boolean waitOutstanding;
+  private boolean noWait;
 
   @CommandLine.Option(
       names = {"-h", "--help"},
@@ -57,7 +57,7 @@ public class AdminCommand implements Callable<Integer> {
     RequestCoordinator coordinator = new RequestCoordinator(srvServiceUrl);
     switch (command) {
       case PAUSE:
-        coordinator.pause(waitOutstanding);
+        coordinator.pause(!noWait);
         System.out.println("Pause completed at " + getCurrentTimeWithFormat());
         break;
       case UNPAUSE:

--- a/src/main/java/com/scalar/admin/AdminCommand.java
+++ b/src/main/java/com/scalar/admin/AdminCommand.java
@@ -35,9 +35,7 @@ public class AdminCommand implements Callable<Integer> {
 
   @CommandLine.Option(
       names = {"--wait-outstanding", "-w"},
-      required = false,
-      defaultValue = "true",
-      paramLabel = "WAIT_OUTSTANDING",
+      defaultValue = "false",
       description =
           "A flag to specify if PAUSE command waits for termination of outstanding requests.")
   private boolean waitOutstanding;


### PR DESCRIPTION
It seems to me that the current behavior with the `--wait-outstanding` option is unexpected.

The current behavior is as follows:
- When executing it without `--wait-outstanding` (the default behavior), it's waiting for termination of outstanding requests
- When executing it with `--wait-outstanding`, it's not waiting for termination of outstanding requests

It looks like the opposite behavior. The change in this PR will fix this issue.

Please take a look!