### PR TITLE
Add a reference to find the URL of the SRV record in Kubernetes

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ $ kubectl run <NAME> -it --image=ghcr.io/scalar-labs/scalar-admin:<version> --re
 
 Note:-
 
+`SRV_SERVICE_URL` is a URL of the SRV record.
 In Kubernetes, You can find the URL of the SRV record with the help of the [SRV records](https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#srv-records) guide.
 
 ## Implement server-side code

--- a/README.md
+++ b/README.md
@@ -57,6 +57,10 @@ If you want to use the `scalar-admin` container on kubernetes, you can do it as 
 $ kubectl run <NAME> -it --image=ghcr.io/scalar-labs/scalar-admin:<version> --restart=Never --rm -- -c <COMMAND> -s <SRV_SERVICE_URL>
 ```
 
+Note:-
+
+In kubernetes, You can find the URL of SRV record with the help of the [SRV records](https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#srv-records) guide.
+
 ## Implement server-side code
 
 To make your services accessible from scalar-admin tool, you need to implement server-side code based on the admin interface defined in [admin.proto](src/main/proto/scalar/protobuf/admin.proto).

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ $ kubectl run <NAME> -it --image=ghcr.io/scalar-labs/scalar-admin:<version> --re
 
 Note:-
 
-In kubernetes, You can find the URL of SRV record with the help of the [SRV records](https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#srv-records) guide.
+In Kubernetes, You can find the URL of the SRV record with the help of the [SRV records](https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#srv-records) guide.
 
 ## Implement server-side code
 


### PR DESCRIPTION
I closed the PR [Create Scalar DL Backup and Restore Guide](https://github.com/scalar-labs/scalar-kubernetes/pull/152) for Kubernetes to avoid redundancy.

[README](https://github.com/scalar-labs/scalar-admin/blob/main/README.md) file of the scalar-admin contains the step for pause and unpause Ledger in Kubernetes.

I checked the following checklist with new changes.
```
Check if all requirements are met
Check if the goal has been achieved
Check if you understand what you are explaining perfectly
Check if all the sentences are clear, concise, easy-to-understand, and well-thought English
Make sure there are no spelling mistakes and grammatical errors
Make sure there is no redundancy
Make sure there is no inconsistency
```

[A Guide on How to Backup and Restore Data in Scalar DL](https://github.com/scalar-labs/scalardl/blob/master/docs/backup-restore.md) will help you create and restore a backup.