### PR TITLE
Upgrade version to 1.2.0

### DIFF
--- a/java/build.gradle
+++ b/java/build.gradle
@@ -88,7 +88,7 @@ targetCompatibility = 1.8
 
 group = "com.scalar-labs"
 archivesBaseName = "scalar-admin"
-version = "1.1.0"
+version = "1.2.0"
 
 // for archiving and uploading to maven central
 //apply from: 'archive.gradle'


### PR DESCRIPTION
This PR upgrades the Java module scalar-admin to 1.2.0 for the new gRPC service `checkPaused`.

After this PR is merged and the module is released, we can upgrade the dependencies in scalar and scalrdb and update the server-side codes.