### PR TITLE
Configure distTar task to set archive name to conform with Dockerfile

### DIFF
--- a/java/build.gradle
+++ b/java/build.gradle
@@ -79,6 +79,10 @@ docker {
     files tasks.distTar.outputs
 }
 
+distTar {
+    archiveFileName = "${project.name}.tar"
+}
+
 shadowJar {
     mergeServiceFiles()
 }


### PR DESCRIPTION
This PR configures the Gradle distTar task to set the archive name to `scalar-admin.tar` instead of the default value `scalar-admin-<version>.tar`.

This is to conform with the [Dockerfile](https://github.com/scalar-labs/scalar-admin/blob/main/java/Dockerfile#L8).

reference: #12 