### PR TITLE
Upgrade Java's version to 2.0.0

### DIFF
--- a/java/build.gradle
+++ b/java/build.gradle
@@ -98,7 +98,7 @@ targetCompatibility = 1.8
 
 group = "com.scalar-labs"
 archivesBaseName = "scalar-admin"
-version = "1.2.0"
+version = "2.0.0"
 
 // for archiving and uploading to maven central
 if (!project.gradle.startParameter.taskNames.isEmpty() &&


### PR DESCRIPTION
This PR revises the Java's module version to 2.0.0 since this version removes a gRPC service.