### PR TITLE
Upgrade the internal JRE Docker image to 1.1.4

### DIFF
--- a/java/Dockerfile
+++ b/java/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/scalar-labs/jre8:1.1.3
+FROM ghcr.io/scalar-labs/jre8:1.1.4
 
 WORKDIR /scalar
 


### PR DESCRIPTION
This PR upgrades the internal JRE Docker image to 1.1.4.