### PR TITLE
Add a new workflow to publish docker images

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,43 @@
+name: Docker Image Publication
+
+on:
+  push:
+    tags:
+      - java-[0-9]+.[0-9]+.[0-9]+
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        working-directory: java
+
+    steps:
+      - name: Set version
+        id: version
+        run: |
+          VERSION=$(echo ${{ github.ref }} | sed -e "s#refs/tags/java-##g")
+          echo ::set-output name=version::${VERSION}
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.CR_PAT }}
+
+      - run: ./gradlew docker
+
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@master
+        with:
+          image-ref: scalar-admin:latest
+          format: 'table'
+          exit-code: '1'
+          ignore-unfixed: true
+          severity: 'CRITICAL,HIGH'
+
+      - run: docker tag scalar-admin:latest ghcr.io/scalar-labs/scalar-admin:${{ steps.version.outputs.version }}
+
+      - run: docker push ghcr.io/scalar-labs/scalar-admin:${{ steps.version.outputs.version }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -29,15 +29,15 @@ jobs:
 
       - run: ./gradlew docker
 
+      - run: docker tag scalar-admin:latest ghcr.io/scalar-labs/scalar-admin:${{ steps.version.outputs.version }}
+
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@master
         with:
-          image-ref: scalar-admin:latest
+          image-ref: ghcr.io/scalar-labs/scalar-admin:${{ steps.version.outputs.version }}
           format: 'table'
           exit-code: '1'
           ignore-unfixed: true
           severity: 'CRITICAL,HIGH'
-
-      - run: docker tag scalar-admin:latest ghcr.io/scalar-labs/scalar-admin:${{ steps.version.outputs.version }}
 
       - run: docker push ghcr.io/scalar-labs/scalar-admin:${{ steps.version.outputs.version }}


### PR DESCRIPTION
This PR creates a GitHub Actions workflow to release the `ghcr.io/scalar-labs/scalar-admin` image.