### PR TITLE
Add a new workflow to publish the Java package

### DIFF
--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -1,0 +1,33 @@
+name: Publish the Java Package to Maven Central Repository
+
+on:
+  push:
+    tags:
+      - java-[0-9]+.[0-9]+.[0-9]+
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        working-directory: java
+
+    steps:
+      - name: Set version
+        id: version
+        run: |
+          VERSION=$(echo ${{ github.ref }} | sed -e "s#refs/tags/java-##g")
+          echo ::set-output name=version::${VERSION}
+
+      - name: Upload the package to Maven Central Repository
+        run: |
+          echo "${{secrets.SIGNING_SECRET_KEY_RING}}" \
+            | base64 -d > ~/.gradle/secring.gpg
+          ./gradlew publish \
+            -Pversion=${{ steps.version.outputs.version }} \
+            -Psigning.keyId="${{ secrets.SIGNING_KEY_ID }}" \
+            -Psigning.password="${{ secrets.SIGNING_PASSWORD }}" \
+            -Psigning.secretKeyRingFile="$(echo ~/.gradle/secring.gpg)" \
+            -PossrhUsername="${{ secrets.OSSRH_USERNAMAE }}" \
+            -PossrhPassword="${{ secrets.OSSRH_PASSWORD }}"


### PR DESCRIPTION
This PR creates a new GitHub Action workflow to publish the Java package to Maven Central Repository.

When a tag `java-x.y.z` is pushed, this workflow will be triggered.

Note: There's another workflow `docker` https://github.com/scalar-labs/scalar-admin/blob/main/.github/workflows/docker.yml to publish the Docker image to GitHub Package Registry.