### PR TITLE
Use log4j version 2

### DIFF
--- a/java/build.gradle
+++ b/java/build.gradle
@@ -16,9 +16,13 @@ repositories {
 
 def grpcVersion = '1.43.2'
 def protobufVersion = '3.19.2'
+def slf4jVersion = '1.7.36'
+def log4jVersion = '2.19.0'
 
 dependencies {
-    compile group: 'org.slf4j', name: 'slf4j-log4j12', version: '1.7.30'
+    compile group: 'org.slf4j', name: 'slf4j-api', version: "${slf4jVersion}"
+    compile group: 'org.apache.logging.log4j', name: 'log4j-core', version: "${log4jVersion}"
+    compile group: 'org.apache.logging.log4j', name: 'log4j-slf4j-impl', version: "${log4jVersion}"
     compile group: 'info.picocli', name: 'picocli', version: '4.0.1'
     compile group: 'javax.json', name: 'javax.json-api', version: '1.1.4'
     compile group: 'org.glassfish', name: 'javax.json', version: '1.1.4'


### PR DESCRIPTION
This PR upgrades log4j to version 2 for vulnerability fix.