### PR TITLE
Fix the `maven-publish` workflow

### DIFF
--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -24,12 +24,11 @@ jobs:
 
       - name: Upload the package to Maven Central Repository
         run: |
-          echo "${{secrets.SIGNING_SECRET_KEY_RING}}" \
-            | base64 -d > ~/.gradle/secring.gpg
+          echo "${{ secrets.SIGNING_SECRET_KEY_RING }}" | base64 -d > ~/.gradle/secring.gpg
           ./gradlew publish \
-            -Pversion=${{ steps.version.outputs.version }} \
-            -Psigning.keyId="${{ secrets.SIGNING_KEY_ID }}" \
-            -Psigning.password="${{ secrets.SIGNING_PASSWORD }}" \
-            -Psigning.secretKeyRingFile="$(echo ~/.gradle/secring.gpg)" \
-            -PossrhUsername="${{ secrets.OSSRH_USERNAMAE }}" \
-            -PossrhPassword="${{ secrets.OSSRH_PASSWORD }}"
+          -Pversion="${{ steps.version.outputs.version }}" \
+          -Psigning.keyId="${{ secrets.SIGNING_KEY_ID }}" \
+          -Psigning.password="${{ secrets.SIGNING_PASSWORD }}" \
+          -Psigning.secretKeyRingFile="$(echo ~/.gradle/secring.gpg)" \
+          -PossrhUsername="${{ secrets.OSSRH_USERNAMAE }}" \
+          -PossrhPassword="${{ secrets.OSSRH_PASSWORD }}"


### PR DESCRIPTION
This PR fixes(?) an issue that I might indent command lines incorrectly.

I am not sure about the behavior of indenting them one more level so better to make them at the same level.