### PR TITLE
Support requesting by ips and ports

### DIFF
--- a/java/src/main/java/com/scalar/admin/AdminCommand.java
+++ b/java/src/main/java/com/scalar/admin/AdminCommand.java
@@ -68,11 +68,12 @@ public class AdminCommand implements Callable<Integer> {
 
   @Override
   public Integer call() {
-    RequestCoordinator coordinator;
+    RequestCoordinator coordinator = null;
 
-    if (srvServiceUrl != null && addresses != null) {
+    if ((srvServiceUrl != null && addresses != null)
+        || (srvServiceUrl == null && addresses == null)) {
       throw new IllegalArgumentException(
-          "Specify only either [--srv-service-url, -s] or [--addresses, -a].");
+          "It's required to specify only either [--srv-service-url, -s] or [--addresses, -a].");
     } else if (srvServiceUrl != null) {
       coordinator = new RequestCoordinator(srvServiceUrl);
     } else if (addresses != null) {
@@ -91,9 +92,6 @@ public class AdminCommand implements Callable<Integer> {
                             hostAndPort[0], Integer.parseInt(hostAndPort[1]));
                       })
                   .collect(Collectors.toList()));
-    } else {
-      throw new IllegalArgumentException(
-          "Either [--srv-service-url, -s] or [--addresses, -a] is required.");
     }
 
     switch (command) {

--- a/java/src/main/java/com/scalar/admin/AdminCommand.java
+++ b/java/src/main/java/com/scalar/admin/AdminCommand.java
@@ -70,7 +70,10 @@ public class AdminCommand implements Callable<Integer> {
   public Integer call() {
     RequestCoordinator coordinator;
 
-    if (srvServiceUrl != null) {
+    if (srvServiceUrl != null && addresses != null) {
+      throw new IllegalArgumentException(
+          "Specify only either [--srv-service-url, -s] or [--addresses, -a].");
+    } else if (srvServiceUrl != null) {
       coordinator = new RequestCoordinator(srvServiceUrl);
     } else if (addresses != null) {
       coordinator =

--- a/java/src/main/java/com/scalar/admin/RequestCoordinator.java
+++ b/java/src/main/java/com/scalar/admin/RequestCoordinator.java
@@ -2,6 +2,7 @@ package com.scalar.admin;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.scalar.admin.exception.AdminException;
+import java.net.InetSocketAddress;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -14,6 +15,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 import javax.json.Json;
@@ -30,10 +32,15 @@ import org.xbill.DNS.Type;
 @Immutable
 public class RequestCoordinator {
   private static final Logger logger = LoggerFactory.getLogger(RequestCoordinator.class);
-  private final String srvServiceUrl;
+  private String srvServiceUrl;
+  private List<InetSocketAddress> addresses;
 
   public RequestCoordinator(String srvServiceUrl) {
     this.srvServiceUrl = srvServiceUrl;
+  }
+
+  public RequestCoordinator(List<InetSocketAddress> addresses) {
+    this.addresses = addresses;
   }
 
   public void pause(boolean waitOutstanding, @Nullable Long maxPauseWaitTime) {
@@ -52,25 +59,35 @@ public class RequestCoordinator {
 
   private Map<String, String> run(Function<AdminClient, Optional<String>> function) {
     // Assume that the list of addresses for unpause is the same as the one for pause.
-    List<SRVRecord> records = getApplicationIps(srvServiceUrl);
+    if (addresses == null) {
+      List<SRVRecord> records = getApplicationIps(srvServiceUrl);
+      addresses =
+          records.stream()
+              .map(
+                  r -> {
+                    return new InetSocketAddress(r.getTarget().toString(true), r.getPort());
+                  })
+              .collect(Collectors.toList());
+    }
 
     ExecutorService executor = Executors.newCachedThreadPool();
     Map<String, Future<Optional<String>>> futures = new HashMap<>();
-    records.forEach(
-        record -> {
-          String target = record.getTarget().toString(true);
-          String address = target + ":" + record.getPort();
+    addresses.forEach(
+        address -> {
+          String host = address.getHostString();
+          int port = address.getPort();
+
           // use Callable to propagate exceptions
           Callable<Optional<String>> task =
               () -> {
-                try (AdminClient client = getClient(target, record.getPort())) {
+                try (AdminClient client = getClient(host, port)) {
                   return function.apply(client);
                 } catch (Exception e) {
                   logger.error(function.toString() + " failed.", e);
                   throw new AdminException(e);
                 }
               };
-          futures.put(address, executor.submit(task));
+          futures.put(host + ":" + port, executor.submit(task));
         });
     executor.shutdown();
 

--- a/java/src/main/java/com/scalar/admin/RequestCoordinator.java
+++ b/java/src/main/java/com/scalar/admin/RequestCoordinator.java
@@ -60,13 +60,9 @@ public class RequestCoordinator {
   private Map<String, String> run(Function<AdminClient, Optional<String>> function) {
     // Assume that the list of addresses for unpause is the same as the one for pause.
     if (addresses == null) {
-      List<SRVRecord> records = getApplicationIps(srvServiceUrl);
       addresses =
-          records.stream()
-              .map(
-                  r -> {
-                    return new InetSocketAddress(r.getTarget().toString(true), r.getPort());
-                  })
+          getApplicationIps(srvServiceUrl).stream()
+              .map(r -> new InetSocketAddress(r.getTarget().toString(true), r.getPort()))
               .collect(Collectors.toList());
     }
 

--- a/java/src/test/java/com/scalar/admin/RequestCoordinatorTest.java
+++ b/java/src/test/java/com/scalar/admin/RequestCoordinatorTest.java
@@ -9,6 +9,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.scalar.admin.exception.AdminException;
+import java.net.InetSocketAddress;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
@@ -72,6 +73,36 @@ public class RequestCoordinatorTest {
   }
 
   @Test
+  public void pause_InetSocketAddressListGiven_ShouldPauseAll() {
+    // Arrange
+    coordinator = // Override setUp
+        Mockito.spy(
+            new RequestCoordinator(
+                Arrays.asList(
+                    new InetSocketAddress(APP_IP1, PORT),
+                    new InetSocketAddress(APP_IP2, PORT),
+                    new InetSocketAddress(APP_IP3, PORT))));
+
+    AdminClient client1 = mock(AdminClient.class);
+    when(coordinator.getClient(APP_IP1, PORT)).thenReturn(client1);
+    AdminClient client2 = mock(AdminClient.class);
+    when(coordinator.getClient(APP_IP2, PORT)).thenReturn(client2);
+    AdminClient client3 = mock(AdminClient.class);
+    when(coordinator.getClient(APP_IP3, PORT)).thenReturn(client3);
+
+    // Act
+    coordinator.pause(true, MAX_PAUSE_WAIT_TIME);
+
+    // Assert
+    verify(coordinator).getClient(APP_IP1, PORT);
+    verify(client1).pause(true, MAX_PAUSE_WAIT_TIME);
+    verify(coordinator).getClient(APP_IP2, PORT);
+    verify(client2).pause(true, MAX_PAUSE_WAIT_TIME);
+    verify(coordinator).getClient(APP_IP3, PORT);
+    verify(client3).pause(true, MAX_PAUSE_WAIT_TIME);
+  }
+
+  @Test
   public void pause_SomeExceptionThrown_ShouldThrowAdminException() throws TextParseException {
     // Arrange
     List<SRVRecord> records = prepareSrvRecords();
@@ -115,6 +146,36 @@ public class RequestCoordinatorTest {
   }
 
   @Test
+  public void unpause_InetSocketAddressListGiven_ShouldUnpauseAll() {
+    // Arrange
+    coordinator = // Override setUp
+        Mockito.spy(
+            new RequestCoordinator(
+                Arrays.asList(
+                    new InetSocketAddress(APP_IP1, PORT),
+                    new InetSocketAddress(APP_IP2, PORT),
+                    new InetSocketAddress(APP_IP3, PORT))));
+
+    AdminClient client1 = mock(AdminClient.class);
+    when(coordinator.getClient(APP_IP1, PORT)).thenReturn(client1);
+    AdminClient client2 = mock(AdminClient.class);
+    when(coordinator.getClient(APP_IP2, PORT)).thenReturn(client2);
+    AdminClient client3 = mock(AdminClient.class);
+    when(coordinator.getClient(APP_IP3, PORT)).thenReturn(client3);
+
+    // Act
+    coordinator.unpause();
+
+    // Assert
+    verify(coordinator).getClient(APP_IP1, PORT);
+    verify(client1).unpause();
+    verify(coordinator).getClient(APP_IP2, PORT);
+    verify(client2).unpause();
+    verify(coordinator).getClient(APP_IP3, PORT);
+    verify(client3).unpause();
+  }
+
+  @Test
   public void unpause_SomeExceptionThrown_ShouldThrowAdminException() throws TextParseException {
     // Arrange
     List<SRVRecord> records = prepareSrvRecords();
@@ -133,10 +194,51 @@ public class RequestCoordinatorTest {
   }
 
   @Test
-  public void paused_SrvServiceUrlGiven_ShouldReturnGetAll() throws TextParseException {
+  public void checkPaused_SrvServiceUrlGiven_ShouldReturnGetAll() throws TextParseException {
     // Arrange
     List<SRVRecord> records = prepareSrvRecords();
     doReturn(records).when(coordinator).getApplicationIps(SRV_SERVICE_URL);
+    AdminClient client1 = mock(AdminClient.class);
+    when(coordinator.getClient(APP_IP1, PORT)).thenReturn(client1);
+    when(client1.checkPaused()).thenReturn(Optional.of("false"));
+    AdminClient client2 = mock(AdminClient.class);
+    when(coordinator.getClient(APP_IP2, PORT)).thenReturn(client2);
+    when(client2.checkPaused()).thenReturn(Optional.of("false"));
+    AdminClient client3 = mock(AdminClient.class);
+    when(coordinator.getClient(APP_IP3, PORT)).thenReturn(client3);
+    when(client3.checkPaused()).thenReturn(Optional.of("false"));
+
+    // Act
+    JsonObject actual = coordinator.checkPaused();
+
+    // Assert
+    verify(coordinator).getClient(APP_IP1, PORT);
+    verify(client1).checkPaused();
+    verify(coordinator).getClient(APP_IP2, PORT);
+    verify(client2).checkPaused();
+    verify(coordinator).getClient(APP_IP3, PORT);
+    verify(client3).checkPaused();
+
+    JsonObject expected =
+        Json.createObjectBuilder()
+            .add(APP_IP1 + ":" + PORT, "false")
+            .add(APP_IP2 + ":" + PORT, "false")
+            .add(APP_IP3 + ":" + PORT, "false")
+            .build();
+    assertThat(actual).isEqualTo(expected);
+  }
+
+  @Test
+  public void checkPaused_InetSocketAddressListGiven_ShouldReturnGetAll() {
+    // Arrange
+    coordinator = // Override setUp
+        Mockito.spy(
+            new RequestCoordinator(
+                Arrays.asList(
+                    new InetSocketAddress(APP_IP1, PORT),
+                    new InetSocketAddress(APP_IP2, PORT),
+                    new InetSocketAddress(APP_IP3, PORT))));
+
     AdminClient client1 = mock(AdminClient.class);
     when(coordinator.getClient(APP_IP1, PORT)).thenReturn(client1);
     when(client1.checkPaused()).thenReturn(Optional.of("false"));


### PR DESCRIPTION
This PR enhances RequestCoordinator to support requesting by IP and port addresses.

The Node part will be in another PR.