### PR TITLE
Upgrade the in-house JRE 8 Docker image to version 1.1.11

### DIFF
--- a/java/Dockerfile
+++ b/java/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/scalar-labs/jre8:1.1.10
+FROM ghcr.io/scalar-labs/jre8:1.1.11
 
 WORKDIR /scalar
 


### PR DESCRIPTION
This PR updates the in-house JRE 8 Docker image to version 1.1.11 for CVE-2023-0286