### PR TITLE
Upgrade the in-house JRE Docker image to 1.1.12

### DIFF
--- a/java/Dockerfile
+++ b/java/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/scalar-labs/jre8:1.1.11
+FROM ghcr.io/scalar-labs/jre8:1.1.12
 
 WORKDIR /scalar
 


### PR DESCRIPTION
This PR upgrades the in-house JRE 8 Docker image to 1.1.12 for fixing CVE-2023-0361.