### PR TITLE
Fix Gradle build system issues about classpath and dependencies

### DIFF
--- a/java/archive.gradle
+++ b/java/archive.gradle
@@ -1,11 +1,6 @@
 apply plugin: 'maven-publish'
 apply plugin: 'signing'
 
-java {
-    withJavadocJar()
-    withSourcesJar()
-}
-
 publishing {
     publications {
         mavenJava(MavenPublication) {

--- a/java/archive.gradle
+++ b/java/archive.gradle
@@ -1,13 +1,16 @@
 apply plugin: 'maven-publish'
 apply plugin: 'signing'
 
+java {
+    withJavadocJar()
+    withSourcesJar()
+}
+
 publishing {
     publications {
         mavenJava(MavenPublication) {
             artifactId = 'scalar-admin'
-            artifact jar
-            artifact javadocJar
-            artifact sourcesJar
+            from components.java
             pom {
                 name = 'Scalar Admin'
                 description = 'An admin interface and tool for Scalar services.'

--- a/java/build.gradle
+++ b/java/build.gradle
@@ -97,6 +97,11 @@ shadowJar {
     mergeServiceFiles()
 }
 
+java {
+    withJavadocJar()
+    withSourcesJar()
+}
+
 sourceCompatibility = 1.8
 targetCompatibility = 1.8
 

--- a/java/build.gradle
+++ b/java/build.gradle
@@ -56,7 +56,7 @@ task AdminCommand(type: CreateStartScripts) {
     mainClassName = 'com.scalar.admin.AdminCommand'
     applicationName = 'scalar-admin'
     outputDir = new File(project.buildDir, 'tmp')
-    classpath = jar.outputs.files + project.configurations.runtime
+    classpath = jar.outputs.files + project.configurations.runtimeClasspath
 }
 
 applicationDistribution.into('bin') {
@@ -102,7 +102,7 @@ targetCompatibility = 1.8
 
 group = "com.scalar-labs"
 archivesBaseName = "scalar-admin"
-version = "2.1.1"
+version = "2.1.2"
 
 // for archiving and uploading to maven central
 if (!project.gradle.startParameter.taskNames.isEmpty() &&

--- a/node/package-lock.json
+++ b/node/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@scalar-labs/scalar-admin",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@scalar-labs/scalar-admin",
-      "version": "2.1.1",
+      "version": "2.1.2",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@grpc/grpc-js": "^1.8.8",

--- a/node/package.json
+++ b/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scalar-labs/scalar-admin",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "description": "The Scalar Admin library for Node.js",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
This PR revises the build system to fix two issues:
- The runtime class path was not included in the bin script
- The dependencies where not included in the BOM file (seems not caused by the `implementation` configuration)