### PR TITLE
Implement TLS support

### DIFF
--- a/java/build.gradle
+++ b/java/build.gradle
@@ -107,7 +107,7 @@ targetCompatibility = 1.8
 
 group = "com.scalar-labs"
 archivesBaseName = "scalar-admin"
-version = "2.1.2"
+version = "2.2.0"
 
 // for archiving and uploading to maven central
 if (!project.gradle.startParameter.taskNames.isEmpty() &&

--- a/java/src/main/java/com/scalar/admin/TlsRequestCoordinator.java
+++ b/java/src/main/java/com/scalar/admin/TlsRequestCoordinator.java
@@ -8,8 +8,8 @@ import javax.annotation.concurrent.Immutable;
 @Immutable
 public class TlsRequestCoordinator extends RequestCoordinator {
 
-  private final String caRootCert;
-  private final String overrideAuthority;
+  @Nullable private final String caRootCert;
+  @Nullable private final String overrideAuthority;
 
   public TlsRequestCoordinator(
       String srvServiceUrl, @Nullable String caRootCert, @Nullable String overrideAuthority) {

--- a/java/src/main/java/com/scalar/admin/TlsRequestCoordinator.java
+++ b/java/src/main/java/com/scalar/admin/TlsRequestCoordinator.java
@@ -1,0 +1,36 @@
+package com.scalar.admin;
+
+import java.net.InetSocketAddress;
+import java.util.List;
+import javax.annotation.Nullable;
+import javax.annotation.concurrent.Immutable;
+
+@Immutable
+public class TlsRequestCoordinator extends RequestCoordinator {
+
+  private final String caRootCert;
+  private final String overrideAuthority;
+
+  public TlsRequestCoordinator(
+      String srvServiceUrl, @Nullable String caRootCert, @Nullable String overrideAuthority) {
+    super(srvServiceUrl);
+
+    this.caRootCert = caRootCert;
+    this.overrideAuthority = overrideAuthority;
+  }
+
+  public TlsRequestCoordinator(
+      List<InetSocketAddress> addresses,
+      @Nullable String caRootCert,
+      @Nullable String overrideAuthority) {
+    super(addresses);
+
+    this.caRootCert = caRootCert;
+    this.overrideAuthority = overrideAuthority;
+  }
+
+  @Override
+  AdminClient getClient(String host, int port) {
+    return new AdminClient(host, port, caRootCert, overrideAuthority);
+  }
+}


### PR DESCRIPTION
## Description

This PR implements the TLS support so that user can pass CA root certificate and override authority to build TLS gRPC connection to targets.

The command-line tool has three more options
- `--tls`
- `--ca-root-cert-path` and `--ca-root-cert-pem`
- `--override-authority`

## Related issues and/or PRs

N/A

## Changes made

- added a new class `TlsRequestCoordinator`
- made AdminClient able to setup SSL context when using netty

## Checklist

- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes.
- [ ] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [ ] Any dependent changes in other PRs have been merged and published.

## Additional notes

- Support TLS connection between scalar-admin clients and servers
