### PR TITLE
Store the keyring in the /tmp

### DIFF
--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -24,11 +24,11 @@ jobs:
 
       - name: Upload the package to Maven Central Repository
         run: |
-          echo "${{ secrets.SIGNING_SECRET_KEY_RING }}" | base64 -d > ~/.gradle/secring.gpg
+          echo "${{ secrets.SIGNING_SECRET_KEY_RING }}" | base64 -d > /tmp/secring.gpg
           ./gradlew publish \
           -Pversion="${{ steps.version.outputs.version }}" \
           -Psigning.keyId="${{ secrets.SIGNING_KEY_ID }}" \
           -Psigning.password="${{ secrets.SIGNING_PASSWORD }}" \
-          -Psigning.secretKeyRingFile="$(echo ~/.gradle/secring.gpg)" \
+          -Psigning.secretKeyRingFile="$(echo /tmp/secring.gpg)" \
           -PossrhUsername="${{ secrets.OSSRH_USERNAMAE }}" \
           -PossrhPassword="${{ secrets.OSSRH_PASSWORD }}"


### PR DESCRIPTION
## Description

This PR fixes a bug that put the keyring file in the `./gradle` folder.
This folder won't exist if we don't run Gradle in advance.

## Related issues and/or PRs

N/A

## Changes made

- revised one GitHub Actions workflow

## Checklist

- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes.
- [ ] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [ ] Tests (unit, integration, etc.) have been added for the changes.
- [ ] My changes generate no new warnings.
- [ ] Any dependent changes in other PRs have been merged and published.
