### PR TITLE
Add a warning message for `-s` option

### DIFF
--- a/src/main/java/com/scalar/admin/AdminCommand.java
+++ b/src/main/java/com/scalar/admin/AdminCommand.java
@@ -111,8 +111,8 @@ public class AdminCommand implements Callable<Integer> {
       throw new IllegalArgumentException(
           "It's required to specify only either [--srv-service-url, -s] or [--addresses, -a].");
     } else if (srvServiceUrl != null) {
-      logger.error(
-          "Warning: --srv-service-url, -s will be deprecated in the future. We recommend using"
+      logger.warn(
+          "--srv-service-url, -s will be deprecated in the future. We recommend using"
               + " --addresses, -a instead.");
       coordinator = createCoordinator(srvServiceUrl);
     } else { // addresses != null

--- a/src/main/java/com/scalar/admin/AdminCommand.java
+++ b/src/main/java/com/scalar/admin/AdminCommand.java
@@ -18,6 +18,8 @@ import javax.json.JsonObject;
 import javax.json.JsonWriter;
 import javax.json.JsonWriterFactory;
 import javax.json.stream.JsonGenerator;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import picocli.CommandLine;
 import picocli.CommandLine.Command;
 
@@ -26,6 +28,8 @@ import picocli.CommandLine.Command;
     description =
         "Execute an admin command for applications that implement scalar admin interface.")
 public class AdminCommand implements Callable<Integer> {
+
+  private static final Logger logger = LoggerFactory.getLogger(AdminCommand.class);
 
   @CommandLine.Option(
       names = {"--command", "-c"},
@@ -107,6 +111,9 @@ public class AdminCommand implements Callable<Integer> {
       throw new IllegalArgumentException(
           "It's required to specify only either [--srv-service-url, -s] or [--addresses, -a].");
     } else if (srvServiceUrl != null) {
+      logger.error(
+          "Warning: --srv-service-url, -s will be deprecated in the future. We recommend using"
+              + " --addresses, -a instead.");
       coordinator = createCoordinator(srvServiceUrl);
     } else { // addresses != null
       coordinator =
@@ -129,10 +136,10 @@ public class AdminCommand implements Callable<Integer> {
     switch (command) {
       case PAUSE:
         coordinator.pause(!noWait, maxPauseWaitTime);
-        System.out.println("Pause completed at " + getCurrentTimeWithFormat());
+        logger.info("Pause completed at {}", getCurrentTimeWithFormat());
         break;
       case UNPAUSE:
-        System.out.println("Unpause started at " + getCurrentTimeWithFormat());
+        logger.info("Unpause started at {}", getCurrentTimeWithFormat());
         coordinator.unpause();
         break;
       case CHECK_PAUSED:
@@ -149,7 +156,7 @@ public class AdminCommand implements Callable<Integer> {
     StringWriter stringWriter = new StringWriter();
     JsonWriter jsonWriter = writerFactory.createWriter(stringWriter);
     jsonWriter.writeObject(json);
-    System.out.println(stringWriter.toString().trim());
+    logger.info(stringWriter.toString().trim());
   }
 
   static String getCurrentTimeWithFormat() {

--- a/src/main/resources/log4j.properties
+++ b/src/main/resources/log4j.properties
@@ -1,6 +1,0 @@
-# logger
-log4j.rootLogger=INFO, console
-# console appender
-log4j.appender.console=org.apache.log4j.ConsoleAppender
-log4j.appender.console.layout=org.apache.log4j.PatternLayout
-log4j.appender.console.layout.ConversionPattern=%d [%-5p %c] %m%n

--- a/src/main/resources/log4j2.properties
+++ b/src/main/resources/log4j2.properties
@@ -1,0 +1,8 @@
+# The root logger with appender name
+rootLogger = INFO, STDOUT
+
+# Assign STDOUT a valid appender & define its layout
+appender.console.name = STDOUT
+appender.console.type = Console
+appender.console.layout.type = PatternLayout
+appender.console.layout.pattern = %msg%n

--- a/src/main/resources/log4j2.properties
+++ b/src/main/resources/log4j2.properties
@@ -5,4 +5,4 @@ rootLogger = INFO, STDOUT
 appender.console.name = STDOUT
 appender.console.type = Console
 appender.console.layout.type = PatternLayout
-appender.console.layout.pattern = %msg%n
+appender.console.layout.pattern = %d %p %C [%t] %m%n


### PR DESCRIPTION
## Description

This PR adds a warning message when the users use the `-s` option. This is advised in #50 

## Related issues and/or PRs

#50 

## Changes made

- remove the old log4j properties and add the log4j2 properties
- added new warning message

## Checklist


- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes.
- [ ] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [ ] Any dependent changes in other PRs have been merged and published.
