### PR TITLE
Fix CVE-2024-25638

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,7 @@ dependencies {
     implementation "io.grpc:grpc-protobuf:${grpcVersion}"
     implementation "io.grpc:grpc-stub:${grpcVersion}"
     implementation "com.google.protobuf:protobuf-java-util:${protobufVersion}"
-    implementation 'dnsjava:dnsjava:2.1.9'
+    implementation 'dnsjava:dnsjava:3.6.1'
     compileOnly 'javax.annotation:javax.annotation-api:1.2'
     testImplementation 'junit:junit:4.12'
     testImplementation 'org.assertj:assertj-core:3.9.1'


### PR DESCRIPTION
## Description

This PR fixes CVE-2024-25638 by bumping up the `dnsjava` library to `3.6.1`.

## Related issues and/or PRs

N/A

## Changes made

- Bumped up the `dnsjava` library to `3.6.1`.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A
