### PR TITLE
Bump Protocol Buffers and gRPC libs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,8 +14,8 @@ repositories {
     mavenCentral()
 }
 
-def grpcVersion = '1.51.0'
-def protobufVersion = '3.21.12'
+def grpcVersion = '1.66.0'
+def protobufVersion = '3.24.4'
 def slf4jVersion = '1.7.36'
 def log4jVersion = '2.19.0'
 


### PR DESCRIPTION
## Description

This PR bumps up the Protocol Buffers and gRPC libs to `3.24.4` and `1.66.0`.

## Related issues and/or PRs

N/A

## Changes made

- Bumped up the Protocol Buffers and gRPC libs to `3.24.4` and `1.66.0`

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A
